### PR TITLE
Enable more GCC warnings

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -2158,7 +2158,7 @@ AC_DEFUN([CURL_VERIFY_RUNTIMELIBS], [
     dnl point also is available run-time!
     AC_MSG_CHECKING([run-time libs availability])
     CURL_RUN_IFELSE([
-main()
+int main()
 {
   return 0;
 }

--- a/configure.ac
+++ b/configure.ac
@@ -61,6 +61,13 @@ AC_SUBST(CONFIGURE_OPTIONS)
 CURL_CFLAG_EXTRAS=""
 if test X"$want_werror" = Xyes; then
   CURL_CFLAG_EXTRAS="-Werror"
+  if test "$compiler_id" = "GNU_C"; then
+    dnl enable -pedantic-errors for GCC 5 and later,
+    dnl as before that it was the same as -Werror=pedantic
+    if test "$compiler_num" -ge "500"; then
+      CURL_CFLAG_EXTRAS="$CURL_CFLAG_EXTRAS -pedantic-errors"
+    fi
+  fi
 fi
 AC_SUBST(CURL_CFLAG_EXTRAS)
 

--- a/docs/examples/sslbackend.c
+++ b/docs/examples/sslbackend.c
@@ -57,9 +57,9 @@ int main(int argc, char **argv)
     return 0;
   }
   else if(isdigit(*name)) {
-    curl_sslbackend id = (curl_sslbackend)atoi(name);
+    int id = atoi(name);
 
-    result = curl_global_sslset(id, NULL, NULL);
+    result = curl_global_sslset((curl_sslbackend)id, NULL, NULL);
   }
   else
     result = curl_global_sslset(-1, name, NULL);

--- a/lib/formdata.c
+++ b/lib/formdata.c
@@ -45,10 +45,6 @@
 #include "memdebug.h"
 
 
-/* What kind of Content-Type to use on un-specified files with unrecognized
-   extensions. */
-#define HTTPPOST_CONTENTTYPE_DEFAULT "application/octet-stream"
-
 #define HTTPPOST_PTRNAME CURL_HTTPPOST_PTRNAME
 #define HTTPPOST_FILENAME CURL_HTTPPOST_FILENAME
 #define HTTPPOST_PTRCONTENTS CURL_HTTPPOST_PTRCONTENTS

--- a/lib/formdata.c
+++ b/lib/formdata.c
@@ -301,7 +301,8 @@ CURLFORMcode FormAdd(struct curl_httppost **httppost,
        * Set the contents property.
        */
     case CURLFORM_PTRCONTENTS:
-      current_form->flags |= HTTPPOST_PTRCONTENTS; /* fall through */
+      current_form->flags |= HTTPPOST_PTRCONTENTS;
+      /* FALLTHROUGH */
     case CURLFORM_COPYCONTENTS:
       if(current_form->value)
         return_value = CURL_FORMADD_OPTION_TWICE;

--- a/lib/http_ntlm.c
+++ b/lib/http_ntlm.c
@@ -228,7 +228,7 @@ CURLcode Curl_output_ntlm(struct connectdata *conn, bool proxy)
     /* connection is already authenticated,
      * don't send a header in future requests */
     ntlm->state = NTLMSTATE_LAST;
-    /* fall-through */
+    /* FALLTHROUGH */
   case NTLMSTATE_LAST:
     Curl_safefree(*allocuserpwd);
     authp->done = TRUE;

--- a/lib/ssh.c
+++ b/lib/ssh.c
@@ -659,7 +659,7 @@ static CURLcode ssh_statemach_act(struct connectdata *conn, bool *block)
       libssh2_session_set_blocking(sshc->ssh_session, 0);
 
       state(conn, SSH_S_STARTUP);
-      /* fall-through */
+      /* FALLTHROUGH */
 
     case SSH_S_STARTUP:
       rc = libssh2_session_startup(sshc->ssh_session, (int)sock);
@@ -675,7 +675,7 @@ static CURLcode ssh_statemach_act(struct connectdata *conn, bool *block)
 
       state(conn, SSH_HOSTKEY);
 
-      /* fall-through */
+      /* FALLTHROUGH */
     case SSH_HOSTKEY:
       /*
        * Before we authenticate we should check the hostkey's fingerprint

--- a/lib/strcase.h
+++ b/lib/strcase.h
@@ -46,6 +46,5 @@ char Curl_raw_toupper(char in);
 #define checkprefix(a,b)    curl_strnequal(a,b,strlen(a))
 
 void Curl_strntoupper(char *dest, const char *src, size_t n);
-char Curl_raw_toupper(char in);
 
 #endif /* HEADER_CURL_STRCASE_H */

--- a/lib/telnet.c
+++ b/lib/telnet.c
@@ -1608,7 +1608,7 @@ static CURLcode telnet_do(struct connectdata *conn, bool *done)
     case 0:                     /* timeout */
       pfd[0].revents = 0;
       pfd[1].revents = 0;
-      /* fall through */
+      /* FALLTHROUGH */
     default:                    /* read! */
       if(pfd[0].revents & POLLIN) {
         /* read data from network */

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -1482,7 +1482,7 @@ static size_t strlen_url(const char *url, bool relative)
     switch(*ptr) {
     case '?':
       left = FALSE;
-      /* fall through */
+      /* FALLTHROUGH */
     default:
       if(urlchar_needs_escaping(*ptr))
         newlen += 2;
@@ -1527,7 +1527,7 @@ static void strcpy_url(char *output, const char *url, bool relative)
     switch(*iptr) {
     case '?':
       left = FALSE;
-      /* fall through */
+      /* FALLTHROUGH */
     default:
       if(urlchar_needs_escaping(*iptr)) {
         snprintf(optr, 4, "%%%02x", *iptr);

--- a/m4/curl-compilers.m4
+++ b/m4/curl-compilers.m4
@@ -977,6 +977,7 @@ AC_DEFUN([CURL_SET_COMPILER_WARNING_OPTS], [
           dnl Only gcc 2.95 or later
           if test "$compiler_num" -ge "295"; then
             tmp_CFLAGS="$tmp_CFLAGS -Wno-long-long"
+            tmp_CFLAGS="$tmp_CFLAGS -Wbad-function-cast"
           fi
           #
           dnl Only gcc 2.96 or later

--- a/m4/curl-compilers.m4
+++ b/m4/curl-compilers.m4
@@ -1012,6 +1012,7 @@ AC_DEFUN([CURL_SET_COMPILER_WARNING_OPTS], [
           dnl Only gcc 3.4 or later
           if test "$compiler_num" -ge "304"; then
             tmp_CFLAGS="$tmp_CFLAGS -Wdeclaration-after-statement"
+            tmp_CFLAGS="$tmp_CFLAGS -Wold-style-definition"
           fi
           #
           dnl Only gcc 4.0 or later
@@ -1030,6 +1031,8 @@ AC_DEFUN([CURL_SET_COMPILER_WARNING_OPTS], [
             tmp_CFLAGS="$tmp_CFLAGS -Wmissing-parameter-type -Wempty-body"
             tmp_CFLAGS="$tmp_CFLAGS -Wclobbered -Wignored-qualifiers"
             tmp_CFLAGS="$tmp_CFLAGS -Wconversion -Wno-sign-conversion -Wvla"
+            dnl required for -Warray-bounds, included in -Wall
+            tmp_CFLAGS="$tmp_CFLAGS -ftree-vrp"
           fi
           #
           dnl Only gcc 4.5 or later
@@ -1045,12 +1048,23 @@ AC_DEFUN([CURL_SET_COMPILER_WARNING_OPTS], [
             tmp_CFLAGS="$tmp_CFLAGS -Wdouble-promotion"
           fi
           #
+          dnl only gcc 4.8 or later
+          if test "$compiler_num" -ge "408"; then
+            tmp_CFLAGS="$tmp_CFLAGS -Wformat=2"
+          fi
+          #
+          dnl Only gcc 5 or later
+          if test "$compiler_num" -ge "500"; then
+            tmp_CFLAGS="$tmp_CFLAGS -Warray-bounds=2"
+          fi
+          #
           dnl Only gcc 6 or later
           if test "$compiler_num" -ge "600"; then
             tmp_CFLAGS="$tmp_CFLAGS -Wshift-negative-value"
             tmp_CFLAGS="$tmp_CFLAGS -Wshift-overflow=2"
-            tmp_CFLAGS="$tmp_CFLAGS -Wnull-dereference"
+            tmp_CFLAGS="$tmp_CFLAGS -Wnull-dereference -fdelete-null-pointer-checks"
             tmp_CFLAGS="$tmp_CFLAGS -Wduplicated-cond"
+            tmp_CFLAGS="$tmp_CFLAGS -Wunused-const-variable"
           fi
           #
           dnl Only gcc 7 or later

--- a/m4/curl-compilers.m4
+++ b/m4/curl-compilers.m4
@@ -1060,6 +1060,7 @@ AC_DEFUN([CURL_SET_COMPILER_WARNING_OPTS], [
             tmp_CFLAGS="$tmp_CFLAGS -Walloc-zero"
             tmp_CFLAGS="$tmp_CFLAGS -Wformat-overflow=2"
             tmp_CFLAGS="$tmp_CFLAGS -Wformat-truncation=2"
+            tmp_CFLAGS="$tmp_CFLAGS -Wimplicit-fallthrough=4"
           fi
           #
         fi

--- a/src/tool_cb_see.c
+++ b/src/tool_cb_see.c
@@ -118,10 +118,12 @@ int tool_seek_cb(void *userdata, curl_off_t offset, int whence)
 
 int tool_ftruncate64(int fd, curl_off_t where)
 {
+  intptr_t handle = _get_osfhandle(fd);
+
   if(_lseeki64(fd, where, SEEK_SET) < 0)
     return -1;
 
-  if(!SetEndOfFile((HANDLE)_get_osfhandle(fd)))
+  if(!SetEndOfFile((HANDLE)handle))
     return -1;
 
   return 0;

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -1826,7 +1826,7 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
         config->default_node_flags = toggle?GETOUT_USEREMOTE:0;
         break;
       }
-      /* fall-through! */
+      /* FALLTHROUGH */
     case 'o': /* --output */
       /* output file */
     {

--- a/src/tool_urlglob.c
+++ b/src/tool_urlglob.c
@@ -34,8 +34,6 @@
 #define GLOBERROR(string, column, code) \
   glob->error = string, glob->pos = column, code
 
-void glob_cleanup(URLGlob* glob);
-
 static CURLcode glob_fixed(URLGlob *glob, char *fixed, size_t len)
 {
   URLPattern *pat = &glob->pattern[glob->size];

--- a/src/tool_urlglob.c
+++ b/src/tool_urlglob.c
@@ -114,7 +114,7 @@ static CURLcode glob_set(URLGlob *glob, char **patternp,
       if(multiply(amount, pat->content.Set.size + 1))
         return GLOBERROR("range overflow", 0, CURLE_URL_MALFORMAT);
 
-      /* fall-through */
+      /* FALLTHROUGH */
     case ',':
 
       *buf = '\0';
@@ -157,7 +157,7 @@ static CURLcode glob_set(URLGlob *glob, char **patternp,
         ++pattern;
         ++(*posp);
       }
-      /* intentional fallthrough */
+      /* FALLTHROUGH */
     default:
       *buf++ = *pattern++;              /* copy character to set element */
       ++(*posp);

--- a/tests/libtest/lib650.c
+++ b/tests/libtest/lib650.c
@@ -62,6 +62,7 @@ int test(char *URL)
   struct curl_forms formarray[3];
   size_t formlength = 0;
   char flbuf[32];
+  long contentlength = 0;
 
   if(curl_global_init(CURL_GLOBAL_ALL) != CURLE_OK) {
     fprintf(stderr, "curl_global_init() failed\n");
@@ -94,11 +95,13 @@ int test(char *URL)
     goto test_cleanup;
   }
 
+  contentlength = (long)(strlen(data) - 1);
+
   /* Use a form array for the non-copy test. */
   formarray[0].option = CURLFORM_PTRCONTENTS;
   formarray[0].value = data;
   formarray[1].option = CURLFORM_CONTENTSLENGTH;
-  formarray[1].value = (char *) strlen(data) - 1;
+  formarray[1].value = (char *)(size_t)contentlength;
   formarray[2].option = CURLFORM_END;
   formarray[2].value = NULL;
   formrc = curl_formadd(&formpost,

--- a/tests/server/sockfilt.c
+++ b/tests/server/sockfilt.c
@@ -782,8 +782,9 @@ static int select_ws(int nfds, fd_set *readfds, fd_set *writefds,
             wsa++;
           }
           else {
+            curl_socket_t socket = curlx_sitosk(fds);
             WSACloseEvent(wsaevent);
-            handle = (HANDLE) curlx_sitosk(fds);
+            handle = (HANDLE) socket;
             handle = select_ws_wait(handle, waitevent);
             handles[nfd] = handle;
             data[thd].thread = handle;


### PR DESCRIPTION
This enables the following additional warnings:
-Wbad-function-cast, as already enabled for clang
-Wdisabled-optimization
-Wold-style-definition
-Wnormalized=nfkc, which warns on identifiers that could be ambiguous
-Warray-bounds also in debug mode through -ftree-vrp
-Wtrampolines
-Wformat=2, but only for GCC 4.8+ as Wno-format-nonliteral is not
 respected for older versions
-Wdate-time for reproducible builds
-Warray-bounds=2 instead of the default 1
-Wnull-dereference also in debug mode through
 -fdelete-null-pointer-checks
-Wunused-const-variable
-Wimplicit-fallthrough=4 instead of the default 3