### PR TITLE
tool: support UTF-16 command line on Windows

### DIFF
--- a/lib/curl_multibyte.c
+++ b/lib/curl_multibyte.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2015, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -20,24 +20,21 @@
  *
  ***************************************************************************/
 
+/*
+ * This file is 'mem-include-scan' clean. See test 1132.
+ */
+
 #include "curl_setup.h"
 
-#include <curl/curl.h>
-
-#if defined(USE_WIN32_IDN) || ((defined(USE_WINDOWS_SSPI) || \
-                                defined(USE_WIN32_LDAP)) && defined(UNICODE))
-
- /*
-  * MultiByte conversions using Windows kernel32 library.
-  */
+#if defined(WIN32)
 
 #include "curl_multibyte.h"
-#include "curl_memory.h"
 
-/* The last #include file should be: */
-#include "memdebug.h"
+/*
+ * MultiByte conversions using Windows kernel32 library.
+ */
 
-wchar_t *Curl_convert_UTF8_to_wchar(const char *str_utf8)
+wchar_t *curlx_convert_UTF8_to_wchar(const char *str_utf8)
 {
   wchar_t *str_w = NULL;
 
@@ -59,7 +56,7 @@ wchar_t *Curl_convert_UTF8_to_wchar(const char *str_utf8)
   return str_w;
 }
 
-char *Curl_convert_wchar_to_UTF8(const wchar_t *str_w)
+char *curlx_convert_wchar_to_UTF8(const wchar_t *str_w)
 {
   char *str_utf8 = NULL;
 
@@ -81,4 +78,4 @@ char *Curl_convert_wchar_to_UTF8(const wchar_t *str_w)
   return str_utf8;
 }
 
-#endif /* USE_WIN32_IDN || ((USE_WINDOWS_SSPI || USE_WIN32_LDAP) && UNICODE) */
+#endif /* WIN32 */

--- a/lib/curl_multibyte.h
+++ b/lib/curl_multibyte.h
@@ -23,45 +23,40 @@
  ***************************************************************************/
 #include "curl_setup.h"
 
-#if defined(USE_WIN32_IDN) || ((defined(USE_WINDOWS_SSPI) || \
-                                defined(USE_WIN32_LDAP)) && defined(UNICODE))
-
- /*
-  * MultiByte conversions using Windows kernel32 library.
-  */
-
-wchar_t *Curl_convert_UTF8_to_wchar(const char *str_utf8);
-char *Curl_convert_wchar_to_UTF8(const wchar_t *str_w);
-
-#endif /* USE_WIN32_IDN || ((USE_WINDOWS_SSPI || USE_WIN32_LDAP) && UNICODE) */
-
-
-#if defined(USE_WIN32_IDN) || defined(USE_WINDOWS_SSPI) || \
-    defined(USE_WIN32_LDAP)
+#if defined(WIN32)
 
 /*
- * Macros Curl_convert_UTF8_to_tchar(), Curl_convert_tchar_to_UTF8()
- * and Curl_unicodefree() main purpose is to minimize the number of
+ * MultiByte conversions using Windows kernel32 library.
+ */
+
+wchar_t *curlx_convert_UTF8_to_wchar(const char *str_utf8);
+char *curlx_convert_wchar_to_UTF8(const wchar_t *str_w);
+
+#endif /* WIN32 */
+
+/*
+ * Macros curlx_convert_UTF8_to_tchar(), curlx_convert_tchar_to_UTF8()
+ * and curlx_unicodefree() main purpose is to minimize the number of
  * preprocessor conditional directives needed by code using these
  * to differentiate UNICODE from non-UNICODE builds.
  *
- * When building with UNICODE defined, this two macros
- * Curl_convert_UTF8_to_tchar() and Curl_convert_tchar_to_UTF8()
+ * When building with UNICODE defined, these two macros
+ * curlx_convert_UTF8_to_tchar() and curlx_convert_tchar_to_UTF8()
  * return a pointer to a newly allocated memory area holding result.
  * When the result is no longer needed, allocated memory is intended
- * to be free'ed with Curl_unicodefree().
+ * to be free'ed with curlx_unicodefree().
  *
  * When building without UNICODE defined, this macros
- * Curl_convert_UTF8_to_tchar() and Curl_convert_tchar_to_UTF8()
- * return the pointer received as argument. Curl_unicodefree() does
+ * curlx_convert_UTF8_to_tchar() and curlx_convert_tchar_to_UTF8()
+ * return the pointer received as argument. curlx_unicodefree() does
  * no actual free'ing of this pointer it is simply set to NULL.
  */
 
-#ifdef UNICODE
+#if defined(UNICODE) && defined(WIN32)
 
-#define Curl_convert_UTF8_to_tchar(ptr) Curl_convert_UTF8_to_wchar((ptr))
-#define Curl_convert_tchar_to_UTF8(ptr) Curl_convert_wchar_to_UTF8((ptr))
-#define Curl_unicodefree(ptr) \
+#define curlx_convert_UTF8_to_tchar(ptr) curlx_convert_UTF8_to_wchar((ptr))
+#define curlx_convert_tchar_to_UTF8(ptr) curlx_convert_wchar_to_UTF8((ptr))
+#define curlx_unicodefree(ptr) \
   do {if((ptr)) {free((ptr)); (ptr) = NULL;}} WHILE_FALSE
 
 typedef union {
@@ -73,9 +68,9 @@ typedef union {
 
 #else
 
-#define Curl_convert_UTF8_to_tchar(ptr) (ptr)
-#define Curl_convert_tchar_to_UTF8(ptr) (ptr)
-#define Curl_unicodefree(ptr) \
+#define curlx_convert_UTF8_to_tchar(ptr) (ptr)
+#define curlx_convert_tchar_to_UTF8(ptr) (ptr)
+#define curlx_unicodefree(ptr) \
   do {(ptr) = NULL;} WHILE_FALSE
 
 typedef union {
@@ -85,8 +80,6 @@ typedef union {
   const unsigned char *const_tbyte_ptr;
 } xcharp_u;
 
-#endif /* UNICODE */
-
-#endif /* USE_WIN32_IDN || USE_WINDOWS_SSPI || USE_WIN32_LDAP */
+#endif /* UNICODE && WIN32 */
 
 #endif /* HEADER_CURL_MULTIBYTE_H */

--- a/lib/curl_setup_once.h
+++ b/lib/curl_setup_once.h
@@ -501,6 +501,8 @@ typedef int sig_atomic_t;
 
 #ifdef __VMS
 #define argv_item_t  __char_ptr32
+#elif defined(_UNICODE)
+#define argv_item_t wchar_t *
 #else
 #define argv_item_t  char *
 #endif

--- a/lib/curl_sspi.c
+++ b/lib/curl_sspi.c
@@ -151,7 +151,7 @@ CURLcode Curl_create_sspi_identity(const char *userp, const char *passwdp,
   /* Initialize the identity */
   memset(identity, 0, sizeof(*identity));
 
-  useranddomain.tchar_ptr = Curl_convert_UTF8_to_tchar((char *)userp);
+  useranddomain.tchar_ptr = curlx_convert_UTF8_to_tchar((char *)userp);
   if(!useranddomain.tchar_ptr)
     return CURLE_OUT_OF_MEMORY;
 
@@ -173,7 +173,7 @@ CURLcode Curl_create_sspi_identity(const char *userp, const char *passwdp,
   /* Setup the identity's user and length */
   dup_user.tchar_ptr = _tcsdup(user.tchar_ptr);
   if(!dup_user.tchar_ptr) {
-    Curl_unicodefree(useranddomain.tchar_ptr);
+    curlx_unicodefree(useranddomain.tchar_ptr);
     return CURLE_OUT_OF_MEMORY;
   }
   identity->User = dup_user.tbyte_ptr;
@@ -183,7 +183,7 @@ CURLcode Curl_create_sspi_identity(const char *userp, const char *passwdp,
   /* Setup the identity's domain and length */
   dup_domain.tchar_ptr = malloc(sizeof(TCHAR) * (domlen + 1));
   if(!dup_domain.tchar_ptr) {
-    Curl_unicodefree(useranddomain.tchar_ptr);
+    curlx_unicodefree(useranddomain.tchar_ptr);
     return CURLE_OUT_OF_MEMORY;
   }
   _tcsncpy(dup_domain.tchar_ptr, domain.tchar_ptr, domlen);
@@ -192,22 +192,22 @@ CURLcode Curl_create_sspi_identity(const char *userp, const char *passwdp,
   identity->DomainLength = curlx_uztoul(domlen);
   dup_domain.tchar_ptr = NULL;
 
-  Curl_unicodefree(useranddomain.tchar_ptr);
+  curlx_unicodefree(useranddomain.tchar_ptr);
 
   /* Setup the identity's password and length */
-  passwd.tchar_ptr = Curl_convert_UTF8_to_tchar((char *)passwdp);
+  passwd.tchar_ptr = curlx_convert_UTF8_to_tchar((char *)passwdp);
   if(!passwd.tchar_ptr)
     return CURLE_OUT_OF_MEMORY;
   dup_passwd.tchar_ptr = _tcsdup(passwd.tchar_ptr);
   if(!dup_passwd.tchar_ptr) {
-    Curl_unicodefree(passwd.tchar_ptr);
+    curlx_unicodefree(passwd.tchar_ptr);
     return CURLE_OUT_OF_MEMORY;
   }
   identity->Password = dup_passwd.tbyte_ptr;
   identity->PasswordLength = curlx_uztoul(_tcslen(dup_passwd.tchar_ptr));
   dup_passwd.tchar_ptr = NULL;
 
-  Curl_unicodefree(passwd.tchar_ptr);
+  curlx_unicodefree(passwd.tchar_ptr);
 
   /* Setup the identity's flags */
   identity->Flags = SECFLAG_WINNT_AUTH_IDENTITY;

--- a/lib/curlx.h
+++ b/lib/curlx.h
@@ -53,6 +53,16 @@
   curlx_uztosi()
 */
 
+#include "curl_multibyte.h"
+/* "curl_multibyte.h" provies these functions and macros:
+
+  curlx_convert_UTF8_to_wchar()
+  curlx_convert_wchar_to_UTF8()
+  curlx_convert_UTF8_to_tchar()
+  curlx_convert_tchar_to_UTF8()
+  curlx_unicodefree()
+*/
+
 /* Now setup curlx_ * names for the functions that are to become curlx_ and
    be removed from a future libcurl official API:
    curlx_getenv

--- a/lib/idn_win32.c
+++ b/lib/idn_win32.c
@@ -72,13 +72,13 @@ bool curl_win32_idn_to_ascii(const char *in, char **out)
 {
   bool success = FALSE;
 
-  wchar_t *in_w = Curl_convert_UTF8_to_wchar(in);
+  wchar_t *in_w = curlx_convert_UTF8_to_wchar(in);
   if(in_w) {
     wchar_t punycode[IDN_MAX_LENGTH];
     int chars = IdnToAscii(0, in_w, -1, punycode, IDN_MAX_LENGTH);
     free(in_w);
     if(chars) {
-      *out = Curl_convert_wchar_to_UTF8(punycode);
+      *out = curlx_convert_wchar_to_UTF8(punycode);
       if(*out)
         success = TRUE;
     }
@@ -91,7 +91,7 @@ bool curl_win32_ascii_to_idn(const char *in, char **out)
 {
   bool success = FALSE;
 
-  wchar_t *in_w = Curl_convert_UTF8_to_wchar(in);
+  wchar_t *in_w = curlx_convert_UTF8_to_wchar(in);
   if(in_w) {
     size_t in_len = wcslen(in_w) + 1;
     wchar_t unicode[IDN_MAX_LENGTH];
@@ -99,7 +99,7 @@ bool curl_win32_ascii_to_idn(const char *in, char **out)
                              unicode, IDN_MAX_LENGTH);
     free(in_w);
     if(chars) {
-      *out = Curl_convert_wchar_to_UTF8(unicode);
+      *out = curlx_convert_wchar_to_UTF8(unicode);
       if(*out)
         success = TRUE;
     }

--- a/lib/ldap.c
+++ b/lib/ldap.c
@@ -233,13 +233,13 @@ static int ldap_win_bind(struct connectdata *conn, LDAP *server,
   PTCHAR inpass = NULL;
 
   if(user && passwd && (conn->data->set.httpauth & CURLAUTH_BASIC)) {
-    inuser = Curl_convert_UTF8_to_tchar((char *) user);
-    inpass = Curl_convert_UTF8_to_tchar((char *) passwd);
+    inuser = curlx_convert_UTF8_to_tchar((char *) user);
+    inpass = curlx_convert_UTF8_to_tchar((char *) passwd);
 
     rc = ldap_simple_bind_s(server, inuser, inpass);
 
-    Curl_unicodefree(inuser);
-    Curl_unicodefree(inpass);
+    curlx_unicodefree(inuser);
+    curlx_unicodefree(inpass);
   }
 #if defined(USE_WINDOWS_SSPI)
   else {
@@ -300,7 +300,7 @@ static CURLcode Curl_ldap(struct connectdata *conn, bool *done)
           ldap_ssl ? "encrypted" : "cleartext");
 
 #if defined(USE_WIN32_LDAP)
-  host = Curl_convert_UTF8_to_tchar(conn->host.name);
+  host = curlx_convert_UTF8_to_tchar(conn->host.name);
   if(!host) {
     result = CURLE_OUT_OF_MEMORY;
 
@@ -511,7 +511,7 @@ static CURLcode Curl_ldap(struct connectdata *conn, bool *done)
       size_t name_len;
 #if defined(USE_WIN32_LDAP)
       TCHAR *dn = ldap_get_dn(server, entryIterator);
-      name = Curl_convert_tchar_to_UTF8(dn);
+      name = curlx_convert_tchar_to_UTF8(dn);
       if(!name) {
         ldap_memfree(dn);
 
@@ -527,7 +527,7 @@ static CURLcode Curl_ldap(struct connectdata *conn, bool *done)
       result = Curl_client_write(conn, CLIENTWRITE_BODY, (char *)"DN: ", 4);
       if(result) {
 #if defined(USE_WIN32_LDAP)
-        Curl_unicodefree(name);
+        curlx_unicodefree(name);
 #endif
         ldap_memfree(dn);
 
@@ -538,7 +538,7 @@ static CURLcode Curl_ldap(struct connectdata *conn, bool *done)
                                  name_len);
       if(result) {
 #if defined(USE_WIN32_LDAP)
-        Curl_unicodefree(name);
+        curlx_unicodefree(name);
 #endif
         ldap_memfree(dn);
 
@@ -548,7 +548,7 @@ static CURLcode Curl_ldap(struct connectdata *conn, bool *done)
       result = Curl_client_write(conn, CLIENTWRITE_BODY, (char *)"\n", 1);
       if(result) {
 #if defined(USE_WIN32_LDAP)
-        Curl_unicodefree(name);
+        curlx_unicodefree(name);
 #endif
         ldap_memfree(dn);
 
@@ -558,7 +558,7 @@ static CURLcode Curl_ldap(struct connectdata *conn, bool *done)
       dlsize += name_len + 5;
 
 #if defined(USE_WIN32_LDAP)
-      Curl_unicodefree(name);
+      curlx_unicodefree(name);
 #endif
       ldap_memfree(dn);
     }
@@ -570,7 +570,7 @@ static CURLcode Curl_ldap(struct connectdata *conn, bool *done)
       BerValue **vals;
       size_t attr_len;
 #if defined(USE_WIN32_LDAP)
-      char *attr = Curl_convert_tchar_to_UTF8(attribute);
+      char *attr = curlx_convert_tchar_to_UTF8(attribute);
       if(!attr) {
         if(ber)
           ber_free(ber, 0);
@@ -591,7 +591,7 @@ static CURLcode Curl_ldap(struct connectdata *conn, bool *done)
           if(result) {
             ldap_value_free_len(vals);
 #if defined(USE_WIN32_LDAP)
-            Curl_unicodefree(attr);
+            curlx_unicodefree(attr);
 #endif
             ldap_memfree(attribute);
             if(ber)
@@ -605,7 +605,7 @@ static CURLcode Curl_ldap(struct connectdata *conn, bool *done)
           if(result) {
             ldap_value_free_len(vals);
 #if defined(USE_WIN32_LDAP)
-            Curl_unicodefree(attr);
+            curlx_unicodefree(attr);
 #endif
             ldap_memfree(attribute);
             if(ber)
@@ -618,7 +618,7 @@ static CURLcode Curl_ldap(struct connectdata *conn, bool *done)
           if(result) {
             ldap_value_free_len(vals);
 #if defined(USE_WIN32_LDAP)
-            Curl_unicodefree(attr);
+            curlx_unicodefree(attr);
 #endif
             ldap_memfree(attribute);
             if(ber)
@@ -640,7 +640,7 @@ static CURLcode Curl_ldap(struct connectdata *conn, bool *done)
             if(result) {
               ldap_value_free_len(vals);
 #if defined(USE_WIN32_LDAP)
-              Curl_unicodefree(attr);
+              curlx_unicodefree(attr);
 #endif
               ldap_memfree(attribute);
               if(ber)
@@ -656,7 +656,7 @@ static CURLcode Curl_ldap(struct connectdata *conn, bool *done)
               if(result) {
                 ldap_value_free_len(vals);
 #if defined(USE_WIN32_LDAP)
-                Curl_unicodefree(attr);
+                curlx_unicodefree(attr);
 #endif
                 ldap_memfree(attribute);
                 if(ber)
@@ -674,7 +674,7 @@ static CURLcode Curl_ldap(struct connectdata *conn, bool *done)
             if(result) {
               ldap_value_free_len(vals);
 #if defined(USE_WIN32_LDAP)
-              Curl_unicodefree(attr);
+              curlx_unicodefree(attr);
 #endif
               ldap_memfree(attribute);
               if(ber)
@@ -690,7 +690,7 @@ static CURLcode Curl_ldap(struct connectdata *conn, bool *done)
           if(result) {
             ldap_value_free_len(vals);
 #if defined(USE_WIN32_LDAP)
-            Curl_unicodefree(attr);
+            curlx_unicodefree(attr);
 #endif
             ldap_memfree(attribute);
             if(ber)
@@ -708,7 +708,7 @@ static CURLcode Curl_ldap(struct connectdata *conn, bool *done)
 
       /* Free the attribute as we are done with it */
 #if defined(USE_WIN32_LDAP)
-      Curl_unicodefree(attr);
+      curlx_unicodefree(attr);
 #endif
       ldap_memfree(attribute);
 
@@ -740,7 +740,7 @@ quit:
 #endif /* HAVE_LDAP_SSL && CURL_HAS_NOVELL_LDAPSDK */
 
 #if defined(USE_WIN32_LDAP)
-  Curl_unicodefree(host);
+  curlx_unicodefree(host);
 #endif
 
   /* no data to transfer */
@@ -884,10 +884,10 @@ static int _ldap_url_parse2(const struct connectdata *conn, LDAPURLDesc *ludp)
 
 #if defined(USE_WIN32_LDAP)
     /* Convert the unescaped string to a tchar */
-    ludp->lud_dn = Curl_convert_UTF8_to_tchar(unescaped);
+    ludp->lud_dn = curlx_convert_UTF8_to_tchar(unescaped);
 
     /* Free the unescaped string as we are done with it */
-    Curl_unicodefree(unescaped);
+    curlx_unicodefree(unescaped);
 
     if(!ludp->lud_dn) {
       rc = LDAP_NO_MEMORY;
@@ -952,10 +952,10 @@ static int _ldap_url_parse2(const struct connectdata *conn, LDAPURLDesc *ludp)
 
 #if defined(USE_WIN32_LDAP)
       /* Convert the unescaped string to a tchar */
-      ludp->lud_attrs[i] = Curl_convert_UTF8_to_tchar(unescaped);
+      ludp->lud_attrs[i] = curlx_convert_UTF8_to_tchar(unescaped);
 
       /* Free the unescaped string as we are done with it */
-      Curl_unicodefree(unescaped);
+      curlx_unicodefree(unescaped);
 
       if(!ludp->lud_attrs[i]) {
         free(attributes);
@@ -1019,10 +1019,10 @@ static int _ldap_url_parse2(const struct connectdata *conn, LDAPURLDesc *ludp)
 
 #if defined(USE_WIN32_LDAP)
     /* Convert the unescaped string to a tchar */
-    ludp->lud_filter = Curl_convert_UTF8_to_tchar(unescaped);
+    ludp->lud_filter = curlx_convert_UTF8_to_tchar(unescaped);
 
     /* Free the unescaped string as we are done with it */
-    Curl_unicodefree(unescaped);
+    curlx_unicodefree(unescaped);
 
     if(!ludp->lud_filter) {
       rc = LDAP_NO_MEMORY;

--- a/lib/socks_sspi.c
+++ b/lib/socks_sspi.c
@@ -158,7 +158,7 @@ CURLcode Curl_SOCKS5_gssapi_negotiate(int sockindex,
   for(;;) {
     TCHAR *sname;
 
-    sname = Curl_convert_UTF8_to_tchar(service_name);
+    sname = curlx_convert_UTF8_to_tchar(service_name);
     if(!sname)
       return CURLE_OUT_OF_MEMORY;
 
@@ -178,7 +178,7 @@ CURLcode Curl_SOCKS5_gssapi_negotiate(int sockindex,
                                                  &sspi_ret_flags,
                                                  &expiry);
 
-    Curl_unicodefree(sname);
+    curlx_unicodefree(sname);
 
     if(sspi_recv_token.pvBuffer) {
       s_pSecFn->FreeContextBuffer(sspi_recv_token.pvBuffer);

--- a/lib/vauth/digest_sspi.c
+++ b/lib/vauth/digest_sspi.c
@@ -280,13 +280,13 @@ CURLcode Curl_override_sspi_http_realm(const char *chlg,
         if(strcasecompare(value, "realm")) {
 
           /* Setup identity's domain and length */
-          domain.tchar_ptr = Curl_convert_UTF8_to_tchar((char *) content);
+          domain.tchar_ptr = curlx_convert_UTF8_to_tchar((char *) content);
           if(!domain.tchar_ptr)
             return CURLE_OUT_OF_MEMORY;
 
           dup_domain.tchar_ptr = _tcsdup(domain.tchar_ptr);
           if(!dup_domain.tchar_ptr) {
-            Curl_unicodefree(domain.tchar_ptr);
+            curlx_unicodefree(domain.tchar_ptr);
             return CURLE_OUT_OF_MEMORY;
           }
 
@@ -295,7 +295,7 @@ CURLcode Curl_override_sspi_http_realm(const char *chlg,
           identity->DomainLength = curlx_uztoul(_tcslen(dup_domain.tchar_ptr));
           dup_domain.tchar_ptr = NULL;
 
-          Curl_unicodefree(domain.tchar_ptr);
+          curlx_unicodefree(domain.tchar_ptr);
         }
         else {
           /* Unknown specifier, ignore it! */
@@ -572,7 +572,7 @@ CURLcode Curl_auth_create_digest_http_message(struct Curl_easy *data,
     resp_buf.pvBuffer   = output_token;
     resp_buf.cbBuffer   = curlx_uztoul(token_max);
 
-    spn = Curl_convert_UTF8_to_tchar((char *) uripath);
+    spn = curlx_convert_UTF8_to_tchar((char *) uripath);
     if(!spn) {
       s_pSecFn->FreeCredentialsHandle(&credentials);
 
@@ -594,7 +594,7 @@ CURLcode Curl_auth_create_digest_http_message(struct Curl_easy *data,
                                                  &chlg_desc, 0,
                                                  digest->http_context,
                                                  &resp_desc, &attrs, &expiry);
-    Curl_unicodefree(spn);
+    curlx_unicodefree(spn);
 
     if(status == SEC_I_COMPLETE_NEEDED ||
        status == SEC_I_COMPLETE_AND_CONTINUE)

--- a/lib/vauth/krb5_sspi.c
+++ b/lib/vauth/krb5_sspi.c
@@ -380,7 +380,7 @@ CURLcode Curl_auth_create_gssapi_security_message(struct Curl_easy *data,
     return CURLE_OUT_OF_MEMORY;
 
   /* Convert the user name to UTF8 when operating with Unicode */
-  user_name = Curl_convert_tchar_to_UTF8(names.sUserName);
+  user_name = curlx_convert_tchar_to_UTF8(names.sUserName);
   if(!user_name) {
     free(trailer);
 
@@ -392,7 +392,7 @@ CURLcode Curl_auth_create_gssapi_security_message(struct Curl_easy *data,
   message = malloc(messagelen);
   if(!message) {
     free(trailer);
-    Curl_unicodefree(user_name);
+    curlx_unicodefree(user_name);
 
     return CURLE_OUT_OF_MEMORY;
   }
@@ -405,7 +405,7 @@ CURLcode Curl_auth_create_gssapi_security_message(struct Curl_easy *data,
   outdata = htonl(max_size) | sec_layer;
   memcpy(message, &outdata, sizeof(outdata));
   strcpy((char *) message + sizeof(outdata), user_name);
-  Curl_unicodefree(user_name);
+  curlx_unicodefree(user_name);
 
   /* Allocate the padding */
   padding = malloc(sizes.cbBlockSize);

--- a/lib/vauth/vauth.c
+++ b/lib/vauth/vauth.c
@@ -89,7 +89,7 @@ TCHAR *Curl_auth_build_spn(const char *service, const char *host,
   }
 
   /* Allocate our TCHAR based SPN */
-  tchar_spn = Curl_convert_UTF8_to_tchar(utf8_spn);
+  tchar_spn = curlx_convert_UTF8_to_tchar(utf8_spn);
   if(!tchar_spn) {
     free(utf8_spn);
 
@@ -97,7 +97,7 @@ TCHAR *Curl_auth_build_spn(const char *service, const char *host,
   }
 
   /* Release the UTF8 variant when operating with Unicode */
-  Curl_unicodefree(utf8_spn);
+  curlx_unicodefree(utf8_spn);
 
   /* Return our newly allocated SPN */
   return tchar_spn;

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -598,7 +598,7 @@ schannel_connect_step1(struct connectdata *conn, int sockindex)
       BYTE cert_thumbprint_data[CERT_THUMBPRINT_DATA_LEN];
       HCERTSTORE cert_store;
 
-      TCHAR *cert_path = Curl_convert_UTF8_to_tchar(data->set.ssl.cert);
+      TCHAR *cert_path = curlx_convert_UTF8_to_tchar(data->set.ssl.cert);
       if(!cert_path)
         return CURLE_OUT_OF_MEMORY;
 
@@ -607,7 +607,7 @@ schannel_connect_step1(struct connectdata *conn, int sockindex)
       if(result != CURLE_OK) {
         failf(data, "schannel: Failed to get certificate location for %s",
               cert_path);
-        Curl_unicodefree(cert_path);
+        curlx_unicodefree(cert_path);
         return result;
       }
 
@@ -621,7 +621,7 @@ schannel_connect_step1(struct connectdata *conn, int sockindex)
               "last error is %x",
               cert_store_name, cert_store_path, GetLastError());
         free(cert_store_path);
-        Curl_unicodefree(cert_path);
+        curlx_unicodefree(cert_path);
         return CURLE_SSL_CERTPROBLEM;
       }
       free(cert_store_path);
@@ -633,7 +633,7 @@ schannel_connect_step1(struct connectdata *conn, int sockindex)
                               CRYPT_STRING_HEX,
                               cert_thumbprint_data, &cert_thumbprint.cbData,
                               NULL, NULL)) {
-        Curl_unicodefree(cert_path);
+        curlx_unicodefree(cert_path);
         return CURLE_SSL_CERTPROBLEM;
       }
 
@@ -641,7 +641,7 @@ schannel_connect_step1(struct connectdata *conn, int sockindex)
         cert_store, X509_ASN_ENCODING | PKCS_7_ASN_ENCODING, 0,
         CERT_FIND_HASH, &cert_thumbprint, NULL);
 
-      Curl_unicodefree(cert_path);
+      curlx_unicodefree(cert_path);
 
       if(client_certs[0]) {
         schannel_cred.cCreds = 1;
@@ -784,7 +784,7 @@ schannel_connect_step1(struct connectdata *conn, int sockindex)
     return CURLE_OUT_OF_MEMORY;
   }
 
-  host_name = Curl_convert_UTF8_to_tchar(hostname);
+  host_name = curlx_convert_UTF8_to_tchar(hostname);
   if(!host_name)
     return CURLE_OUT_OF_MEMORY;
 
@@ -801,7 +801,7 @@ schannel_connect_step1(struct connectdata *conn, int sockindex)
     0, &BACKEND->ctxt->ctxt_handle,
     &outbuf_desc, &BACKEND->ret_flags, &BACKEND->ctxt->time_stamp);
 
-  Curl_unicodefree(host_name);
+  curlx_unicodefree(host_name);
 
   if(sspi_status != SEC_I_CONTINUE_NEEDED) {
     char buffer[STRERROR_LEN];
@@ -985,7 +985,7 @@ schannel_connect_step2(struct connectdata *conn, int sockindex)
     memcpy(inbuf[0].pvBuffer, BACKEND->encdata_buffer,
            BACKEND->encdata_offset);
 
-    host_name = Curl_convert_UTF8_to_tchar(hostname);
+    host_name = curlx_convert_UTF8_to_tchar(hostname);
     if(!host_name)
       return CURLE_OUT_OF_MEMORY;
 
@@ -996,7 +996,7 @@ schannel_connect_step2(struct connectdata *conn, int sockindex)
       host_name, BACKEND->req_flags, 0, 0, &inbuf_desc, 0, NULL,
       &outbuf_desc, &BACKEND->ret_flags, &BACKEND->ctxt->time_stamp);
 
-    Curl_unicodefree(host_name);
+    curlx_unicodefree(host_name);
 
     /* free buffer for received handshake data */
     Curl_safefree(inbuf[0].pvBuffer);
@@ -2013,7 +2013,7 @@ static int Curl_schannel_shutdown(struct connectdata *conn, int sockindex)
             Curl_sspi_strerror(sspi_status, buffer, sizeof(buffer)));
     }
 
-    host_name = Curl_convert_UTF8_to_tchar(hostname);
+    host_name = curlx_convert_UTF8_to_tchar(hostname);
     if(!host_name)
       return CURLE_OUT_OF_MEMORY;
 
@@ -2035,7 +2035,7 @@ static int Curl_schannel_shutdown(struct connectdata *conn, int sockindex)
       &BACKEND->ret_flags,
       &BACKEND->ctxt->time_stamp);
 
-    Curl_unicodefree(host_name);
+    curlx_unicodefree(host_name);
 
     if((sspi_status == SEC_E_OK) || (sspi_status == SEC_I_CONTEXT_EXPIRED)) {
       /* send close message which is in output buffer */

--- a/lib/vtls/schannel_verify.c
+++ b/lib/vtls/schannel_verify.c
@@ -94,7 +94,7 @@ static CURLcode add_certs_to_store(HCERTSTORE trust_store,
   int num_certs = 0;
   size_t END_CERT_LEN;
 
-  ca_file_tstr = Curl_convert_UTF8_to_tchar((char *)ca_file);
+  ca_file_tstr = curlx_convert_UTF8_to_tchar((char *)ca_file);
   if(!ca_file_tstr) {
     char buffer[STRERROR_LEN];
     failf(data,
@@ -283,7 +283,7 @@ cleanup:
     CloseHandle(ca_file_handle);
   }
   Curl_safefree(ca_file_buffer);
-  Curl_unicodefree(ca_file_tstr);
+  curlx_unicodefree(ca_file_tstr);
 
   return result;
 }
@@ -361,7 +361,7 @@ static CURLcode verify_host(struct Curl_easy *data,
      * is acceptable since both values are assumed to use ASCII
      * (or some equivalent) encoding
      */
-    cert_hostname = Curl_convert_tchar_to_UTF8(
+    cert_hostname = curlx_convert_tchar_to_UTF8(
         &cert_hostname_buff[cert_hostname_buff_index]);
     if(!cert_hostname) {
       result = CURLE_OUT_OF_MEMORY;
@@ -393,7 +393,7 @@ static CURLcode verify_host(struct Curl_easy *data,
 
         result = CURLE_PEER_FAILED_VERIFICATION;
       }
-      Curl_unicodefree(cert_hostname);
+      curlx_unicodefree(cert_hostname);
     }
   }
 
@@ -407,7 +407,7 @@ static CURLcode verify_host(struct Curl_easy *data,
     failf(data, "schannel: server certificate name verification failed");
 
 cleanup:
-  Curl_unicodefree(cert_hostname_buff);
+  curlx_unicodefree(cert_hostname_buff);
 
   return result;
 }

--- a/projects/generate.bat
+++ b/projects/generate.bat
@@ -285,6 +285,7 @@ rem
       call :element %1 lib "nonblock.c" %3
       call :element %1 lib "warnless.c" %3
       call :element %1 lib "curl_ctype.c" %3
+      call :element %1 lib "curl_multibyte.c" %3
     ) else if "!var!" == "CURL_SRC_X_H_FILES" (
       call :element %1 lib "config-win32.h" %3
       call :element %1 lib "curl_setup.h" %3
@@ -292,6 +293,7 @@ rem
       call :element %1 lib "nonblock.h" %3
       call :element %1 lib "warnless.h" %3
       call :element %1 lib "curl_ctype.h" %3
+      call :element %1 lib "curl_multibyte.h" %3
     ) else if "!var!" == "CURL_LIB_C_FILES" (
       for /f "delims=" %%c in ('dir /b ..\lib\*.c') do call :element %1 lib "%%c" %3
     ) else if "!var!" == "CURL_LIB_H_FILES" (

--- a/src/Makefile.inc
+++ b/src/Makefile.inc
@@ -13,14 +13,16 @@ CURLX_CFILES = \
   ../lib/strtoofft.c \
   ../lib/nonblock.c \
   ../lib/warnless.c \
-  ../lib/curl_ctype.c
+  ../lib/curl_ctype.c \
+  ../lib/curl_multibyte.c
 
 CURLX_HFILES = \
   ../lib/curl_setup.h \
   ../lib/strtoofft.h \
   ../lib/nonblock.h \
   ../lib/warnless.h \
-  ../lib/curl_ctype.h
+  ../lib/curl_ctype.h \
+  ../lib/curl_multibyte.h
 
 CURL_CFILES = \
   slist_wc.c \

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -1955,7 +1955,7 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
       }
       {
         /* byte range requested */
-        char *tmp_range;
+        const char *tmp_range;
         tmp_range = nextarg;
         while(*tmp_range != '\0') {
           if(!ISDIGIT(*tmp_range) && *tmp_range != '-' && *tmp_range != ',') {

--- a/src/tool_main.c
+++ b/src/tool_main.c
@@ -285,7 +285,11 @@ static void restore_terminal(void)
 /*
 ** curl tool main function.
 */
+#ifdef _UNICODE
+int wmain(int argc, wchar_t *argv[])
+#else
 int main(int argc, char *argv[])
+#endif
 {
   CURLcode result = CURLE_OK;
   struct GlobalConfig global;
@@ -307,10 +311,10 @@ int main(int argc, char *argv[])
      this point */
   result = main_init(&global);
 
-#ifdef WIN32
+#if defined(WIN32) && defined(_tcscmp)
   /* Undocumented diagnostic option to list the full paths of all loaded
      modules, regardless of whether or not initialization succeeded. */
-  if(argc == 2 && !strcmp(argv[1], "--dump-module-paths")) {
+  if(argc == 2 && !_tcscmp(argv[1], _T("--dump-module-paths"))) {
     struct curl_slist *item, *head = GetLoadedModulePaths();
     for(item = head; item; item = item->next) {
       printf("%s\n", item->data);
@@ -320,7 +324,7 @@ int main(int argc, char *argv[])
       main_free(&global);
   }
   else
-#endif /* WIN32 */
+#endif /* WIN32 && _tcscmp */
   if(!result) {
     /* Start our curl operation */
     result = operate(&global, argc, argv);

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -2025,6 +2025,7 @@ static CURLcode operate_do(struct GlobalConfig *global,
 CURLcode operate(struct GlobalConfig *config, int argc, argv_item_t argv[])
 {
   CURLcode result = CURLE_OK;
+  char *first_arg = curlx_convert_tchar_to_UTF8(argv[1]);
 
   /* Setup proper locale from environment */
 #ifdef HAVE_SETLOCALE
@@ -2033,8 +2034,8 @@ CURLcode operate(struct GlobalConfig *config, int argc, argv_item_t argv[])
 
   /* Parse .curlrc if necessary */
   if((argc == 1) ||
-     (!curl_strequal(argv[1], "-q") &&
-      !curl_strequal(argv[1], "--disable"))) {
+     (!curl_strequal(first_arg, "-q") &&
+      !curl_strequal(first_arg, "--disable"))) {
     parseconfig(NULL, config); /* ignore possible failure */
 
     /* If we had no arguments then make sure a url was specified in .curlrc */
@@ -2043,6 +2044,8 @@ CURLcode operate(struct GlobalConfig *config, int argc, argv_item_t argv[])
       result = CURLE_FAILED_INIT;
     }
   }
+
+  curlx_unicodefree(first_arg);
 
   if(!result) {
     /* Parse the command line arguments */

--- a/src/tool_paramhlp.c
+++ b/src/tool_paramhlp.c
@@ -521,7 +521,7 @@ int ftpcccmethod(struct OperationConfig *config, const char *str)
   return CURLFTPSSL_CCC_PASSIVE;
 }
 
-long delegation(struct OperationConfig *config, char *str)
+long delegation(struct OperationConfig *config, const char *str)
 {
   if(curl_strequal("none", str))
     return CURLGSSAPI_DELEGATION_NONE;

--- a/src/tool_paramhlp.h
+++ b/src/tool_paramhlp.h
@@ -49,7 +49,7 @@ int ftpfilemethod(struct OperationConfig *config, const char *str);
 
 int ftpcccmethod(struct OperationConfig *config, const char *str);
 
-long delegation(struct OperationConfig *config, char *str);
+long delegation(struct OperationConfig *config, const char *str);
 
 ParameterError str2tls_max(long *val, const char *str);
 

--- a/tests/server/Makefile.inc
+++ b/tests/server/Makefile.inc
@@ -5,14 +5,16 @@ CURLX_SRCS = \
  ../../lib/nonblock.c \
  ../../lib/strtoofft.c \
  ../../lib/warnless.c \
- ../../lib/curl_ctype.c
+ ../../lib/curl_ctype.c \
+ ../../lib/curl_multibyte.c
 
 CURLX_HDRS = \
  ../../lib/curlx.h \
  ../../lib/nonblock.h \
  ../../lib/strtoofft.h \
  ../../lib/warnless.h \
- ../../lib/curl_ctype.h
+ ../../lib/curl_ctype.h \
+ ../../lib/curl_multibyte.h
 
 USEFUL = \
  getpart.c \


### PR DESCRIPTION
- use wmain instead of main when _UNICODE is defined [0]
- define argv_item_t as wchar_t * in this case
- use the curl_multibyte gear to convert the command-line arguments to
  UTF-8
- make a few char pointers point to const char instead

This makes it possible to pass parameters with characters outside of
the current locale on Windows, which is required for some tests, e.g.
the IDN tests. Out of the box, this currently only works with the
Visual Studio project files, which default to Unicode.

[0] https://devblogs.microsoft.com/oldnewthing/?p=40643

Ref: https://github.com/curl/curl/issues/3747
Closes