### PR TITLE
system_win32: add missing curl.h include

### DIFF
--- a/lib/system_win32.h
+++ b/lib/system_win32.h
@@ -28,6 +28,8 @@
 
 #ifdef _WIN32
 
+#include <curl/curl.h>
+
 extern LARGE_INTEGER Curl_freq;
 extern bool Curl_isVistaOrGreater;
 extern bool Curl_isWindows8OrGreater;


### PR DESCRIPTION
It's required for `CURLcode`.